### PR TITLE
Fix boolean conversion

### DIFF
--- a/src/configHelpers.ts
+++ b/src/configHelpers.ts
@@ -35,7 +35,7 @@ export function loadEnvironmentVariable(key: string, expectedType: ConfigValueTy
     switch (expectedType) {
         case "boolean":
             if (["true", "false"].includes(value)) {
-                return Boolean(value);
+                return value === "true";
             }
             break;
         case "number":


### PR DESCRIPTION
Fixes boolean conversion when reading from environment variables.

Issue:
`Boolean(stringValue)` always evaluates to true, so `Boolean("false")` becomes `true` when resolving value.