### PR TITLE
Update empty environment variable processing

### DIFF
--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -38,7 +38,7 @@ class ConfigManager {
         }
 
         // 3. Load the values from the environment variables (overrides any value already set by a previous step).
-        const envKeys = getEnvironmentVariableKeys();
+        const envKeys = getEnvironmentVariableKeys(options?.ignoreEmptyEnvironmentVariables);
         const knownEnvKeys = envKeys.filter(envKey => configNamePropertyMapping.has(envKey));
         knownEnvKeys.forEach(key => {
             const configValueOptions = configNamePropertyMapping.get(key)!;

--- a/src/__tests__/ConfigManager.spec.ts
+++ b/src/__tests__/ConfigManager.spec.ts
@@ -59,6 +59,32 @@ describe("ConfigManager", () => {
                 expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("HeyWorld");
             });
 
+            it("should override default values with env variables when set to empty string", () => {
+                // Arange
+                envVariables = { HELLO_WORLD: "" };
+                setEnvVariables(envVariables);
+
+                // Act
+                expect(() => Configs.add(ExampleClass, {})).not.toThrow();
+
+                // Assert
+                const configInstance = Configs.get(ExampleClass);
+                expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("");
+            });
+
+            it("should ignore env variables with empty values if filtered", () => {
+                // Arange
+                envVariables = { HELLO_WORLD: "" };
+                setEnvVariables(envVariables);
+
+                // Act
+                expect(() => Configs.add(ExampleClass, { ignoreEmptyEnvironmentVariables: true })).not.toThrow();
+
+                // Assert
+                const configInstance = Configs.get(ExampleClass);
+                expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("HelloWorld");
+            });
+
             it("should not throw when the given config yml file doesn't exist", () => {
                 expect(() => Configs.add(ExampleClass, { configYmlPath: "doesntexist" })).not.toThrow();
             });

--- a/src/configHelpers.ts
+++ b/src/configHelpers.ts
@@ -20,8 +20,12 @@ export function loadConfigfromYaml(configPath: string, isRequired = false): Reco
     return Yaml.load(configPath);
 }
 
-export function getEnvironmentVariableKeys(): string[] {
-    return Object.keys(process.env);
+export function getEnvironmentVariableKeys(filterEmptyValues = false): string[] {
+    return filterEmptyValues
+        ? Object.entries(process.env)
+              .filter(([, value]) => value != "")
+              .map(([key]) => key)
+        : Object.keys(process.env);
 }
 
 export function loadEnvironmentVariable(key: string, expectedType: ConfigValueType) {
@@ -42,8 +46,7 @@ export function checkValue(envObject: NodeJS.ProcessEnv, key: string, expectedTy
             if (value !== "" && !Number.isNaN(Number(value))) return Number(value);
             break;
         case "string":
-            if (value !== "") return value;
-            break;
+            return value;
     }
 
     throw new Error(`Invalid ENV value of property '${key}', which should be of type '${expectedType}' but got '${value}'.`);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,6 +1,6 @@
 import { Configs } from "./ConfigManager";
 import { addConfigField } from "./configMetadata";
-import { ConfigValueOptions, ClassTypeNoArgs } from "./types";
+import { ConfigValueOptions, ClassTypeNoArgs, ConfigOptions } from "./types";
 
 /**
  * A class decorator's return value will always be called with Classname on code initialisation.
@@ -9,10 +9,6 @@ import { ConfigValueOptions, ClassTypeNoArgs } from "./types";
  * We only allow a constructor without args, so we can instantiate and check all (required) property values right away.
  */
 type ClassTypeDecorator<T extends object> = (clazz: ClassTypeNoArgs<T>) => void;
-
-type ConfigOptions = {
-    configYmlPath?: string;
-};
 
 export function Config<T extends object>(options?: ConfigOptions): ClassTypeDecorator<T> {
     return clazz => Configs.add(clazz, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,4 +49,9 @@ export type ConfigOptions = {
      * By default false.
      */
     configYmlRequired?: boolean;
+
+    /**
+     * By default false.
+     */
+    ignoreEmptyEnvironmentVariables?: boolean;
 };


### PR DESCRIPTION
- Ability to skip processing empty environment variables (controlled with `ignoreEmptyEnvironmentVariables` option)
- Fix error when an environment variable intentionally set empty
```
Invalid ENV value of property 'MY_ENV_VAR_WITH_EMPTY_VALUE', which should be of type 'string' but got ''.
```