### PR TITLE
Handle empty environment variables v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Library for accessing your config variables in a typed manner, with runtime chec
     ```typescript
     import { Config, ConfigValue } from "typed-configs";
 
-    @Config({ configYmlPath: "configs/test.yml" })
+    @Config({ configYmlPath: "configs/test.yml", ignoreEmptyValues: false })
     export class Communicator {
         @ConfigValue({
             name: "GREETING",

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -38,7 +38,7 @@ class ConfigManager {
         }
 
         // 3. Load the values from the environment variables (overrides any value already set by a previous step).
-        const envKeys = getEnvironmentVariableKeys();
+        const envKeys = getEnvironmentVariableKeys(options?.ignoreEmptyEnvironmentVariables);
         const knownEnvKeys = envKeys.filter(envKey => configNamePropertyMapping.has(envKey));
         knownEnvKeys.forEach(key => {
             const configValueOptions = configNamePropertyMapping.get(key)!;

--- a/src/__tests__/ConfigManager.spec.ts
+++ b/src/__tests__/ConfigManager.spec.ts
@@ -59,6 +59,32 @@ describe("ConfigManager", () => {
                 expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("HeyWorld");
             });
 
+            it("should override default values with env variables when set to empty string", () => {
+                // Arange
+                envVariables = { HELLO_WORLD: "" };
+                setEnvVariables(envVariables);
+
+                // Act
+                expect(() => Configs.add(ExampleClass, {})).not.toThrow();
+
+                // Assert
+                const configInstance = Configs.get(ExampleClass);
+                expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("");
+            });
+
+            it("should ignore env variables with empty values if filtered", () => {
+                // Arange
+                envVariables = { HELLO_WORLD: "" };
+                setEnvVariables(envVariables);
+
+                // Act
+                expect(() => Configs.add(ExampleClass, { ignoreEmptyEnvironmentVariables: true })).not.toThrow();
+
+                // Assert
+                const configInstance = Configs.get(ExampleClass);
+                expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("HelloWorld");
+            });
+
             it("should not throw when the given config yml file doesn't exist", () => {
                 expect(() => Configs.add(ExampleClass, { configYmlPath: "doesntexist" })).not.toThrow();
             });

--- a/src/__tests__/ConfigManager.spec.ts
+++ b/src/__tests__/ConfigManager.spec.ts
@@ -69,16 +69,16 @@ describe("ConfigManager", () => {
 
                 // Assert
                 const configInstance = Configs.get(ExampleClass);
-                expect(configInstance.propertyDefaultHelloWorld).toStrictEqual("");
+                expect(configInstance.propertyDefaultHelloWorld).toStrictEqual(undefined);
             });
 
-            it("should ignore env variables with empty values if filtered", () => {
+            it("should ignore empty values if 'ignoreEmptyValues' is set", () => {
                 // Arange
                 envVariables = { HELLO_WORLD: "" };
                 setEnvVariables(envVariables);
 
                 // Act
-                expect(() => Configs.add(ExampleClass, { ignoreEmptyEnvironmentVariables: true })).not.toThrow();
+                expect(() => Configs.add(ExampleClass, { ignoreEmptyValues: true })).not.toThrow();
 
                 // Assert
                 const configInstance = Configs.get(ExampleClass);

--- a/src/__tests__/TestConfig.yml
+++ b/src/__tests__/TestConfig.yml
@@ -1,0 +1,19 @@
+NUMBER_VALUE: 42
+STRING_VALUE: Hello, World!
+BOOLEAN_VALUE: true
+LIST_VALUE:
+  - item1
+  - item2
+  - item3
+DICTIONARY_VALUE:
+  key1: value1
+  key2: value2
+  key3: value3
+NESTED_LIST:
+  - item1
+  - item2
+  - item3:
+      subitem1: value1
+      subitem2: value2
+EMPTY_STRING: ""
+EMPTY_VALUE: null

--- a/src/__tests__/__snapshots__/configHelpers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/configHelpers.spec.ts.snap
@@ -1,15 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`configHelpers checkValue when expecting a boolean should throw when a non-valid string boolean is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got 'treu'."`;
+exports[`configHelpers getValue when expecting a boolean should throw when a non-valid string boolean is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got 'treu'."`;
 
-exports[`configHelpers checkValue when expecting a boolean should throw when a non-valid string boolean is given 2`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got '0'."`;
+exports[`configHelpers getValue when expecting a boolean should throw when a non-valid string boolean is given 2`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got '0'."`;
 
-exports[`configHelpers checkValue when expecting a boolean should throw when a non-valid string boolean is given 3`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got '1'."`;
+exports[`configHelpers getValue when expecting a boolean should throw when a non-valid string boolean is given 3`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got '1'."`;
 
-exports[`configHelpers checkValue when expecting a number should throw when a non-valid number string is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'not-a-number'."`;
+exports[`configHelpers getValue when expecting a number should throw when a non-valid number is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'NaN'."`;
 
-exports[`configHelpers checkValue when expecting a number should throw when a non-valid number string is given 2`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'one'."`;
+exports[`configHelpers getValue when expecting a number should throw when a non-valid number string is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'not-a-number'."`;
 
-exports[`configHelpers checkValue when expecting a number should throw when a non-valid number string is given 3`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'NaN'."`;
+exports[`configHelpers getValue when expecting a number should throw when a non-valid number string is given 2`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'one'."`;
 
-exports[`configHelpers checkValue when expecting a number should throw when a non-valid number string is given 4`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got '1 1'."`;
+exports[`configHelpers getValue when expecting a number should throw when a non-valid number string is given 3`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got '1 1'."`;
+
+exports[`configHelpers getValueFromString when expecting a boolean should throw when a non-valid string boolean is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got 'treu'."`;
+
+exports[`configHelpers getValueFromString when expecting a boolean should throw when a non-valid string boolean is given 2`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got '0'."`;
+
+exports[`configHelpers getValueFromString when expecting a boolean should throw when a non-valid string boolean is given 3`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'boolean' but got '1'."`;
+
+exports[`configHelpers getValueFromString when expecting a number should throw when a non-valid number string is given 1`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'not-a-number'."`;
+
+exports[`configHelpers getValueFromString when expecting a number should throw when a non-valid number string is given 2`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'one'."`;
+
+exports[`configHelpers getValueFromString when expecting a number should throw when a non-valid number string is given 3`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got 'NaN'."`;
+
+exports[`configHelpers getValueFromString when expecting a number should throw when a non-valid number string is given 4`] = `"Invalid ENV value of property 'TEST_KEY', which should be of type 'number' but got '1 1'."`;
+
+exports[`configHelpers loadConfigfromYaml should throw an error when the config file does not exist and is required 1`] = `"Configuration file 'nonexistent.yml' does not exist"`;

--- a/src/__tests__/configHelpers.spec.ts
+++ b/src/__tests__/configHelpers.spec.ts
@@ -1,50 +1,146 @@
-import { checkValue } from "../configHelpers";
+import { getValue, getValueFromString, loadConfigfromYaml } from "../configHelpers";
 
 describe("configHelpers", () => {
-    describe("checkValue", () => {
-        it("should return undefined when key isn't in the env object", () => {
-            // expect(() => checkValue({}, "TEST_KEY", "string")).toThrow("Target ExampleClass doesn't have any config fields.");
-            expect(checkValue({}, "TEST_KEY", "string")).toBeUndefined();
-        });
-
+    describe("getValueFromString", () => {
         describe("when expecting a string", () => {
             it("should return a string when either 'true' or 'false' is passed", () => {
-                expect(checkValue({ TEST_KEY: "true" }, "TEST_KEY", "string")).toBe("true");
-                expect(checkValue({ TEST_KEY: "false" }, "TEST_KEY", "string")).toBe("false");
+                expect(getValueFromString("TEST_KEY", "true", "string")).toBe("true");
+                expect(getValueFromString("TEST_KEY", "false", "string")).toBe("false");
             });
 
             it("should return a string when a number is given", () => {
-                expect(checkValue({ TEST_KEY: "8080" }, "TEST_KEY", "string")).toBe("8080");
-                expect(checkValue({ TEST_KEY: "-1" }, "TEST_KEY", "string")).toBe("-1");
+                expect(getValueFromString("TEST_KEY", "8080", "string")).toBe("8080");
+                expect(getValueFromString("TEST_KEY", "-1", "string")).toBe("-1");
             });
         });
 
         describe("when expecting a boolean", () => {
             it("should return a boolean when either 'true' or 'false' is passed", () => {
-                expect(checkValue({ TEST_KEY: "true" }, "TEST_KEY", "boolean")).toBe(true);
-                expect(checkValue({ TEST_KEY: "false" }, "TEST_KEY", "boolean")).toBe(false);
+                expect(getValueFromString("TEST_KEY", "true", "boolean")).toBe(true);
+                expect(getValueFromString("TEST_KEY", "false", "boolean")).toBe(false);
             });
 
             it("should throw when a non-valid string boolean is given", () => {
-                expect(() => checkValue({ TEST_KEY: "treu" }, "TEST_KEY", "boolean")).toThrowErrorMatchingSnapshot();
-                expect(() => checkValue({ TEST_KEY: "0" }, "TEST_KEY", "boolean")).toThrowErrorMatchingSnapshot();
-                expect(() => checkValue({ TEST_KEY: "1" }, "TEST_KEY", "boolean")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "treu", "boolean")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "0", "boolean")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "1", "boolean")).toThrowErrorMatchingSnapshot();
             });
         });
 
         describe("when expecting a number", () => {
             it("should return a number when a valid number string is passed", () => {
-                expect(checkValue({ TEST_KEY: "8080" }, "TEST_KEY", "number")).toBe(8080);
-                expect(checkValue({ TEST_KEY: "-1" }, "TEST_KEY", "number")).toBe(-1);
-                expect(checkValue({ TEST_KEY: "1.1" }, "TEST_KEY", "number")).toBe(1.1);
+                expect(getValueFromString("TEST_KEY", "8080", "number")).toBe(8080);
+                expect(getValueFromString("TEST_KEY", "-1", "number")).toBe(-1);
+                expect(getValueFromString("TEST_KEY", "1.1", "number")).toBe(1.1);
             });
 
             it("should throw when a non-valid number string is given", () => {
-                expect(() => checkValue({ TEST_KEY: "not-a-number" }, "TEST_KEY", "number")).toThrowErrorMatchingSnapshot();
-                expect(() => checkValue({ TEST_KEY: "one" }, "TEST_KEY", "number")).toThrowErrorMatchingSnapshot();
-                expect(() => checkValue({ TEST_KEY: "NaN" }, "TEST_KEY", "number")).toThrowErrorMatchingSnapshot();
-                expect(() => checkValue({ TEST_KEY: "1 1" }, "TEST_KEY", "number")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "not-a-number", "number")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "one", "number")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "NaN", "number")).toThrowErrorMatchingSnapshot();
+                expect(() => getValueFromString("TEST_KEY", "1 1", "number")).toThrowErrorMatchingSnapshot();
             });
+        });
+    });
+
+    describe("getValue", () => {
+        it("should return undefined when the value is not set", () => {
+            expect(getValue("TEST_KEY", undefined, "string")).toBeUndefined();
+            expect(getValue("TEST_KEY", null, "string")).toBeUndefined();
+            expect(getValue("TEST_KEY", "", "string")).toBeUndefined();
+        });
+
+        describe("when expecting a string", () => {
+            it("should return a string when either true or false is passed", () => {
+                expect(getValue("TEST_KEY", "true", "string")).toBe("true");
+                expect(getValue("TEST_KEY", "false", "string")).toBe("false");
+            });
+
+            it("should return a string when a number is given", () => {
+                expect(getValue("TEST_KEY", "8080", "string")).toBe("8080");
+                expect(getValue("TEST_KEY", "-1", "string")).toBe("-1");
+            });
+        });
+
+        describe("when expecting a boolean", () => {
+            it("should return a boolean when either true or false is passed", () => {
+                expect(getValue("TEST_KEY", true, "boolean")).toBe(true);
+                expect(getValue("TEST_KEY", false, "boolean")).toBe(false);
+            });
+
+            it("should return a boolean when either 'true' or 'false' is passed", () => {
+                expect(getValueFromString("TEST_KEY", "true", "boolean")).toBe(true);
+                expect(getValueFromString("TEST_KEY", "false", "boolean")).toBe(false);
+            });
+
+            it("should throw when a non-valid string boolean is given", () => {
+                expect(() => getValue("TEST_KEY", "treu", "boolean")).toThrowErrorMatchingSnapshot();
+                expect(() => getValue("TEST_KEY", 0, "boolean")).toThrowErrorMatchingSnapshot();
+                expect(() => getValue("TEST_KEY", 1, "boolean")).toThrowErrorMatchingSnapshot();
+            });
+        });
+
+        describe("when expecting a number", () => {
+            it("should return a number when a valid number string is passed", () => {
+                expect(getValue("TEST_KEY", 8080, "number")).toBe(8080);
+                expect(getValue("TEST_KEY", -1, "number")).toBe(-1);
+                expect(getValue("TEST_KEY", 1.1, "number")).toBe(1.1);
+            });
+
+            it("should return a number when a valid number string is passed", () => {
+                expect(getValue("TEST_KEY", "8080", "number")).toBe(8080);
+                expect(getValue("TEST_KEY", "-1", "number")).toBe(-1);
+                expect(getValue("TEST_KEY", "1.1", "number")).toBe(1.1);
+            });
+
+            it("should throw when a non-valid number string is given", () => {
+                expect(() => getValue("TEST_KEY", "not-a-number", "number")).toThrowErrorMatchingSnapshot();
+                expect(() => getValue("TEST_KEY", "one", "number")).toThrowErrorMatchingSnapshot();
+                expect(() => getValue("TEST_KEY", "1 1", "number")).toThrowErrorMatchingSnapshot();
+            });
+
+            it("should throw when a non-valid number is given", () => {
+                expect(() => getValue("TEST_KEY", NaN, "number")).toThrowErrorMatchingSnapshot();
+            });
+        });
+    });
+
+    describe("loadConfigfromYaml", () => {
+        // This test is relevant because we need to ensure that config files are loaded as we expect when checking their values
+        it("should load the config from a YAML file", () => {
+            const config = loadConfigfromYaml(__dirname + "/TestConfig.yml", true);
+
+            expect(config).toEqual({
+                BOOLEAN_VALUE: true,
+                DICTIONARY_VALUE: {
+                    key1: "value1",
+                    key2: "value2",
+                    key3: "value3"
+                },
+                EMPTY_STRING: "",
+                EMPTY_VALUE: null,
+                LIST_VALUE: ["item1", "item2", "item3"],
+                NESTED_LIST: [
+                    "item1",
+                    "item2",
+                    {
+                        item3: {
+                            subitem1: "value1",
+                            subitem2: "value2"
+                        }
+                    }
+                ],
+                NUMBER_VALUE: 42,
+                STRING_VALUE: "Hello, World!"
+            });
+        });
+
+        it("should throw an error when the config file does not exist and is required", () => {
+            expect(() => loadConfigfromYaml("nonexistent.yml", true)).toThrowErrorMatchingSnapshot();
+        });
+
+        it("should not throw an error when the config file does not exist and is not required", () => {
+            expect(() => loadConfigfromYaml("nonexistent.yml")).not.toThrow();
         });
     });
 });

--- a/src/configHelpers.ts
+++ b/src/configHelpers.ts
@@ -20,8 +20,12 @@ export function loadConfigfromYaml(configPath: string, isRequired = false): Reco
     return Yaml.load(configPath);
 }
 
-export function getEnvironmentVariableKeys(): string[] {
-    return Object.keys(process.env);
+export function getEnvironmentVariableKeys(filterEmptyValues = false): string[] {
+    return filterEmptyValues
+        ? Object.entries(process.env)
+              .filter(([, value]) => value != "")
+              .map(([key]) => key)
+        : Object.keys(process.env);
 }
 
 export function loadEnvironmentVariable(key: string, expectedType: ConfigValueType) {
@@ -42,8 +46,7 @@ export function checkValue(envObject: NodeJS.ProcessEnv, key: string, expectedTy
             if (value !== "" && !Number.isNaN(Number(value))) return Number(value);
             break;
         case "string":
-            if (value !== "") return value;
-            break;
+            return value;
     }
 
     throw new Error(`Invalid ENV value of property '${key}', which should be of type '${expectedType}' but got '${value}'.`);

--- a/src/configMetadata.ts
+++ b/src/configMetadata.ts
@@ -10,6 +10,8 @@ const configValuesSymbol = Symbol("configValues");
  */
 const ENV_KEY_REGEX = /^([A-Z_])[A-Z\d_]*$/;
 
+const EMPTY_VALUES = new Set(["", undefined, null]);
+
 /**
  * @param classPrototype Class.prototype (only thing available when using property decorators)
  * @param property name of the property we're registering
@@ -97,7 +99,7 @@ export function validateRequiredConfigValues(instance: object, clazz: ClassTypeN
     const configMap = getConfigValueOptionsMap(clazz.prototype);
     configMap.forEach((valueOptions, property) => {
         const value = (instance as Record<string, any>)[property];
-        if (valueOptions.required && ["", undefined, null].includes(value)) {
+        if (valueOptions.required && isEmptyValue(value)) {
             throw new Error(`Required value for property '${valueOptions.name}' has not been set.`);
         }
     });
@@ -139,4 +141,8 @@ export function getConfigValueOptionsMap(prototype: object) {
     }
 
     return (prototype as any)[configValuesSymbol] as Map<string, AllConfigValueData>;
+}
+
+export function isEmptyValue(value: any): value is undefined | null | "" {
+    return EMPTY_VALUES.has(value);
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,6 +1,6 @@
 import { Configs } from "./ConfigManager";
 import { addConfigField } from "./configMetadata";
-import { ConfigValueOptions, ClassTypeNoArgs } from "./types";
+import { ConfigValueOptions, ClassTypeNoArgs, ConfigOptions } from "./types";
 
 /**
  * A class decorator's return value will always be called with Classname on code initialisation.
@@ -9,10 +9,6 @@ import { ConfigValueOptions, ClassTypeNoArgs } from "./types";
  * We only allow a constructor without args, so we can instantiate and check all (required) property values right away.
  */
 type ClassTypeDecorator<T extends object> = (clazz: ClassTypeNoArgs<T>) => void;
-
-type ConfigOptions = {
-    configYmlPath?: string;
-};
 
 export function Config<T extends object>(options?: ConfigOptions): ClassTypeDecorator<T> {
     return clazz => Configs.add(clazz, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type ConfigSnapshot = Record<string, SupportedConfigTypes>;
 
 export type ConfigOptions = {
     configYmlPath?: string;
+
     /**
      * By default false.
      */
@@ -53,5 +54,5 @@ export type ConfigOptions = {
     /**
      * By default false.
      */
-    ignoreEmptyEnvironmentVariables?: boolean;
+    ignoreEmptyValues?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,4 +49,9 @@ export type ConfigOptions = {
      * By default false.
      */
     configYmlRequired?: boolean;
+
+    /**
+     * By default false.
+     */
+    ignoreEmptyEnvironmentVariables?: boolean;
 };


### PR DESCRIPTION
- Be able to ignore empty strings from both yaml and env (`ignoreEmptyValues`)
- Be able to allow empty strings (and null + undefined) to set certain values in a config (default)
- Validate the type of not only env variables but also yaml variables, which for some reason wasn't happening yet
- Add more unit tests for all of this